### PR TITLE
Change core dump restriction to use replace_or_add

### DIFF
--- a/recipes/core_dumps.rb
+++ b/recipes/core_dumps.rb
@@ -1,5 +1,14 @@
 # Begin xccdf_org.cisecurity.benchmarks_rule_1.6.1_Restrict_Core_Dumps
-template '/etc/security/limits.conf' do
- source 'limits.erb'
+
+case node["platform_family"]
+when 'rhel'
+
+  replace_or_add "Restrict Core Dumps" do
+    path '/etc/security/limits.conf'
+    pattern "^\A\*\shard\score\s0"
+    line "* hard core 0"
+  end
+
 end
+
 # End xccdf_org.cisecurity.benchmarks_rule_1.6.1_Restrict_Core_Dumps

--- a/templates/limits.erb
+++ b/templates/limits.erb
@@ -1,1 +1,0 @@
-* hard core 0

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe 'cis-el7-l1-hardening::default' do
-  # Serverspec examples can be found at
-  # http://serverspec.org/resource_types.html
-  it 'does something' do
-    skip 'Replace this with meaningful tests'
-  end
-end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,8 +1,0 @@
-require 'serverspec'
-
-if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
-  set :backend, :exec
-else
-  set :backend, :cmd
-  set :os, family: 'windows'
-end


### PR DESCRIPTION
@cjohannsen81 was on the right path to using a template but the remediation cookbook needs to have an approach of only modifying what it needs to remediate. 

Changing so instead of managing the file, we are adding the line. 
