### PR TITLE
Amend recipes to fix some rubocop offenses

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -7,7 +7,7 @@ case node['platform_family']
 when 'rhel'
   if node['platform_version'].to_f >= 7.0
 
-# Begin xccdf_org.cisecurity.benchmarks_rule_6.1.2_Enable_crond_Daemon
+    # Begin xccdf_org.cisecurity.benchmarks_rule_6.1.2_Enable_crond_Daemon
     package 'Install cronie' do
       package_name 'cronie'
       action :install
@@ -17,9 +17,9 @@ when 'rhel'
       provider Chef::Provider::Service::Systemd
       action [:enable, :start]
     end
-# End xccdf_org.cisecurity.benchmarks_rule_6.1.2_Enable_crond_Daemon
+    # End xccdf_org.cisecurity.benchmarks_rule_6.1.2_Enable_crond_Daemon
 
-# Begin xccdf_org.cisecurity.benchmarks_rule_6.1.1_Enable_anacron_Daemon
+    # Begin xccdf_org.cisecurity.benchmarks_rule_6.1.1_Enable_anacron_Daemon
 
     package 'Install cronie-anacron' do
       package_name 'cronie-anacron'
@@ -30,17 +30,17 @@ when 'rhel'
       package_name 'crontabs.noarch'
       action :install
     end
-# End xccdf_org.cisecurity.benchmarks_rule_6.1.1_Enable_anacron_Daemon
+    # End xccdf_org.cisecurity.benchmarks_rule_6.1.1_Enable_anacron_Daemon
 
-# Start fix for hardening of cronfiles
+    # Start fix for hardening of cronfiles
     ['/etc/cron.d', '/etc/cron.monthly', '/etc/cron.weekly',
      '/etc/cron.daily', '/etc/cron.hourly'].each do |crondir|
-       directory crondir do
+      directory crondir do
         mode '0700'
         owner 'root'
         group 'root'
         action :create
-       end
+      end
     end
 
     ['/etc/crontab', '/etc/anacrontab'].each do |cronfile|
@@ -51,9 +51,9 @@ when 'rhel'
         action :create
       end
     end
-# End fix for hardening of cronfiles
+    # End fix for hardening of cronfiles
 
-# Begin xccdf_org.cisecurity.benchmarks_rule_6.1.11_Restrict_atcron_to_Authorized_Users
+    # Begin xccdf_org.cisecurity.benchmarks_rule_6.1.11_Restrict_atcron_to_Authorized_Users
     file '/etc/cron.deny' do
       action :delete
     end
@@ -64,7 +64,7 @@ when 'rhel'
       owner 'root'
       group 'root'
     end
-# End xccdf_org.cisecurity.benchmarks_rule_6.1.11_Restrict_atcron_to_Authorized_Users
+    # End xccdf_org.cisecurity.benchmarks_rule_6.1.11_Restrict_atcron_to_Authorized_Users
 
   end
 end

--- a/recipes/network-packet-remediation.rb
+++ b/recipes/network-packet-remediation.rb
@@ -3,7 +3,6 @@
 #
 # Copyright (c) 2016 The Authors, All Rights Reserved.
 
-
 case node['platform_family']
 when 'rhel'
 
@@ -28,64 +27,64 @@ when 'rhel'
   end
 
   # Addresses Log Suspicious Packets
-  replace_or_add "enable_update_net.ipv4.conf.all.log_martians=1" do
-    path "/etc/sysctl.conf"
-    pattern "net.ipv4.conf.all.log_martians"
-    line "net.ipv4.conf.all.log_martians=1"
+  replace_or_add 'enable_update_net.ipv4.conf.all.log_martians=1' do
+    path '/etc/sysctl.conf'
+    pattern 'net.ipv4.conf.all.log_martians'
+    line 'net.ipv4.conf.all.log_martians=1'
   end
-  replace_or_add "enable_net.ipv4.conf.default.log_martians=1" do
-    path "/etc/sysctl.conf"
-    pattern "net.ipv4.conf.default.log_martians"
-    line "net.ipv4.conf.default.log_martians=1"
+  replace_or_add 'enable_net.ipv4.conf.default.log_martians=1' do
+    path '/etc/sysctl.conf'
+    pattern 'net.ipv4.conf.default.log_martians'
+    line 'net.ipv4.conf.default.log_martians=1'
   end
-  execute "update_net.ipv4.conf.all.log_martians=1" do
-    command "/sbin/sysctl -w net.ipv4.conf.all.log_martians=1"
+  execute 'update_net.ipv4.conf.all.log_martians=1' do
+    command '/sbin/sysctl -w net.ipv4.conf.all.log_martians=1'
     not_if '/sbin/sysctl -q -n net.ipv4.conf.all.log_martians | /usr/bin/grep 1'
   end
-  execute "update_net.ipv4.conf.default.log_martians=1" do
-    command "/sbin/sysctl -w net.ipv4.conf.default.log_martians=1"
+  execute 'update_net.ipv4.conf.default.log_martians=1' do
+    command '/sbin/sysctl -w net.ipv4.conf.default.log_martians=1'
     not_if '/sbin/sysctl -q -n net.ipv4.conf.default.log_martians | /usr/bin/grep 1'
   end
   # End
 
   # Addresses Send Packet Redirects
-  replace_or_add "enable_net.ipv4.conf.all.send_redirects=0" do
-    path "/etc/sysctl.conf"
-    pattern "net.ipv4.conf.all.send_redirects"
-    line "net.ipv4.conf.all.send_redirects=0"
+  replace_or_add 'enable_net.ipv4.conf.all.send_redirects=0' do
+    path '/etc/sysctl.conf'
+    pattern 'net.ipv4.conf.all.send_redirects'
+    line 'net.ipv4.conf.all.send_redirects=0'
   end
-  replace_or_add "enable_net.ipv4.conf.default.send_redirects=0" do
-    path "/etc/sysctl.conf"
-    pattern "net.ipv4.conf.default.send_redirects"
-    line "net.ipv4.conf.default.send_redirects=0"
+  replace_or_add 'enable_net.ipv4.conf.default.send_redirects=0' do
+    path '/etc/sysctl.conf'
+    pattern 'net.ipv4.conf.default.send_redirects'
+    line 'net.ipv4.conf.default.send_redirects=0'
   end
-  execute "update_net.ipv4.conf.all.send_redirects=0" do
-    command "/sbin/sysctl -w net.ipv4.conf.all.send_redirects=0"
+  execute 'update_net.ipv4.conf.all.send_redirects=0' do
+    command '/sbin/sysctl -w net.ipv4.conf.all.send_redirects=0'
     not_if '/sbin/sysctl -q -n net.ipv4.conf.all.send_redirects | /usr/bin/grep 0'
   end
-  execute "update_net.ipv4.conf.default.send_redirects=0" do
-    command "/sbin/sysctl -w net.ipv4.conf.default.send_redirects=0"
+  execute 'update_net.ipv4.conf.default.send_redirects=0' do
+    command '/sbin/sysctl -w net.ipv4.conf.default.send_redirects=0'
     not_if '/sbin/sysctl -q -n net.ipv4.conf.default.send_redirects | /usr/bin/grep 0'
   end
   # End of Send Packet Redirects
 
   # Addresses ICMP Redirect Acceptance
-  replace_or_add "enable_net.ipv4.conf.all.accept_redirects=0" do
-    path "/etc/sysctl.conf"
-    pattern "net.ipv4.conf.all.accept_redirects"
-    line "net.ipv4.conf.all.accept_redirects=0"
+  replace_or_add 'enable_net.ipv4.conf.all.accept_redirects=0' do
+    path '/etc/sysctl.conf'
+    pattern 'net.ipv4.conf.all.accept_redirects'
+    line 'net.ipv4.conf.all.accept_redirects=0'
   end
-  replace_or_add "enable_net.ipv4.conf.default.accept_redirects=0" do
-    path "/etc/sysctl.conf"
-    pattern "net.ipv4.conf.default.accept_redirects"
-    line "net.ipv4.conf.default.accept_redirects=0"
+  replace_or_add 'enable_net.ipv4.conf.default.accept_redirects=0' do
+    path '/etc/sysctl.conf'
+    pattern 'net.ipv4.conf.default.accept_redirects'
+    line 'net.ipv4.conf.default.accept_redirects=0'
   end
-  execute "update_net.ipv4.conf.all.accept_redirects=0" do
-    command "/sbin/sysctl -w net.ipv4.conf.all.accept_redirects=0"
+  execute 'update_net.ipv4.conf.all.accept_redirects=0' do
+    command '/sbin/sysctl -w net.ipv4.conf.all.accept_redirects=0'
     not_if '/sbin/sysctl -q -n net.ipv4.conf.all.accept_redirects | /usr/bin/grep 0'
   end
-  execute "update_net.ipv4.conf.default.accept_redirects=0" do
-    command "/sbin/sysctl -w net.ipv4.conf.default.accept_redirects=0"
+  execute 'update_net.ipv4.conf.default.accept_redirects=0' do
+    command '/sbin/sysctl -w net.ipv4.conf.default.accept_redirects=0'
     not_if '/sbin/sysctl -q -n net.ipv4.conf.default.accept_redirects | /usr/bin/grep 0'
   end
   # End ICMP Redirect Acceptance

--- a/recipes/rsyslog.rb
+++ b/recipes/rsyslog.rb
@@ -16,8 +16,8 @@ end
 
 replace_or_add 'Configure rsyslog to send logs to remote host' do
   path '/etc/rsyslog.conf'
-  pattern "#*.* @@remote-host:514"
-  line "*.* @@remote-host:514"
+  pattern '#*.* @@remote-host:514'
+  line '*.* @@remote-host:514'
   notifies :restart, 'service[rsyslog.service]', :immediately
 end
 # End fix for xccdf_org.cisecurity.benchmarks_rule_5.1.5_Configure_rsyslog_to_Send_Logs_to_a_Remote_Log_Host

--- a/recipes/ssh.rb
+++ b/recipes/ssh.rb
@@ -40,8 +40,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.1_Set_SSH_Protocol_to_2
     replace_or_add 'SSH Protocol' do
       path '/etc/ssh/sshd_config'
-      pattern "Protocol 1"
-      line "Protocol 2"
+      pattern 'Protocol 1'
+      line 'Protocol 2'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.1_Set_SSH_Protocol_to_2
@@ -49,8 +49,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.5_Set_SSH_MaxAuthTries_to_4_or_Less
     replace_or_add 'SSH MaxAuthTries' do
       path '/etc/ssh/sshd_config'
-      pattern "MaxAuthTries.*"
-      line "MaxAuthTries 4"
+      pattern 'MaxAuthTries.*'
+      line 'MaxAuthTries 4'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.5_Set_SSH_MaxAuthTries_to_4_or_Less
@@ -58,8 +58,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.4_Disable_SSH_X11_Forwarding
     replace_or_add 'Disable SSH X11 Forwarding' do
       path '/etc/ssh/sshd_config'
-      pattern "X11Forwarding.*"
-      line "X11Forwarding no"
+      pattern 'X11Forwarding.*'
+      line 'X11Forwarding no'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.4_Disable_SSH_X11_Forwarding
@@ -67,8 +67,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.6_Set_SSH_IgnoreRhosts_to_Yes
     replace_or_add 'Set SSH IgnoreRhosts to Yes' do
       path '/etc/ssh/sshd_config'
-      pattern "IgnoreRhosts.*"
-      line "IgnoreRhosts yes"
+      pattern 'IgnoreRhosts.*'
+      line 'IgnoreRhosts yes'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.6_Set_SSH_IgnoreRhosts_to_Yes
@@ -76,14 +76,14 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.14_Set_SSH_Banner
     replace_or_add 'Set SSH Banner' do
       path '/etc/ssh/sshd_config'
-      pattern "Banner.*"
-      line "Banner /etc/ssh/sshd-banner"
+      pattern 'Banner.*'
+      line 'Banner /etc/ssh/sshd-banner'
       notifies :create, 'file[sshd.changed]', :immediately
     end
 
     delete_lines 'Remove no default banner comment' do
       path '/etc/ssh/sshd_config'
-      pattern "# no default banner path"
+      pattern '# no default banner path'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.6_Set_SSH_IgnoreRhosts_to_Yes
@@ -91,8 +91,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.9_Set_SSH_PermitEmptyPasswords_to_No
     replace_or_add 'Set SSH PermitEmptyPasswords to No' do
       path '/etc/ssh/sshd_config'
-      pattern "PermitEmptyPasswords.*"
-      line "PermitEmptyPasswords no"
+      pattern 'PermitEmptyPasswords.*'
+      line 'PermitEmptyPasswords no'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.9_Set_SSH_PermitEmptyPasswords_to_No
@@ -100,8 +100,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.8_Disable_SSH_Root_Login
     replace_or_add 'Disable SSH Root Login' do
       path '/etc/ssh/sshd_config'
-      pattern "PermitRootLogin.*"
-      line "PermitRootLogin no"
+      pattern 'PermitRootLogin.*'
+      line 'PermitRootLogin no'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.8_Disable_SSH_Root_Login
@@ -109,8 +109,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.7_Set_SSH_HostbasedAuthentication_to_No
     replace_or_add 'Set SSH HostbasedAuthentication to No' do
       path '/etc/ssh/sshd_config'
-      pattern "HostbasedAuthentication.*"
-      line "HostbasedAuthentication no"
+      pattern 'HostbasedAuthentication.*'
+      line 'HostbasedAuthentication no'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.7_Set_SSH_HostbasedAuthentication_to_No
@@ -118,8 +118,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.2_Set_LogLevel_to_INFO
     replace_or_add 'Set LogLevel to INFO' do
       path '/etc/ssh/sshd_config'
-      pattern "LogLevel.*"
-      line "LogLevel INFO"
+      pattern 'LogLevel.*'
+      line 'LogLevel INFO'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.2_Set_LogLevel_to_INFO
@@ -127,15 +127,15 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.12_Set_Idle_Timeout_Interval_for_User_Login
     replace_or_add 'Set Idle Timeout Interval for User Login - ClientAliveInterval' do
       path '/etc/ssh/sshd_config'
-      pattern "ClientAliveInterval.*"
-      line "ClientAliveInterval 300"
+      pattern 'ClientAliveInterval.*'
+      line 'ClientAliveInterval 300'
       notifies :create, 'file[sshd.changed]', :immediately
     end
 
     replace_or_add 'Set Idle Timeout Interval for User Login - ClientAliveCountMax' do
       path '/etc/ssh/sshd_config'
-      pattern "ClientAliveCountMax.*"
-      line "ClientAliveCountMax 0"
+      pattern 'ClientAliveCountMax.*'
+      line 'ClientAliveCountMax 0'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.12_Set_Idle_Timeout_Interval_for_User_Login
@@ -143,8 +143,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.10_Do_Not_Allow_Users_to_Set_Environment_Options
     replace_or_add 'Do Not Allow Users to Set Environment Options' do
       path '/etc/ssh/sshd_config'
-      pattern "PermitUserEnvironment.*"
-      line "PermitUserEnvironment no"
+      pattern 'PermitUserEnvironment.*'
+      line 'PermitUserEnvironment no'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.10_Do_Not_Allow_Users_to_Set_Environment_Options
@@ -152,15 +152,15 @@ when 'rhel'
     # Begin fix for xccdf_org.cisecurity.benchmarks_rule_6.2.13_Limit_Access_via_SSH
     replace_or_add 'Set a DenyUsers config up' do
       path '/etc/ssh/sshd_config'
-      pattern "DenyUsers.*"
-      line "DenyUsers root"
+      pattern 'DenyUsers.*'
+      line 'DenyUsers root'
       notifies :create, 'file[sshd.changed]', :immediately
     end
 
     replace_or_add 'Set a DenyGroups config up' do
       path '/etc/ssh/sshd_config'
-      pattern "DenyGroups.*"
-      line "DenyGroups root"
+      pattern 'DenyGroups.*'
+      line 'DenyGroups root'
       notifies :create, 'file[sshd.changed]', :immediately
     end
 
@@ -169,8 +169,8 @@ when 'rhel'
     # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.2.11_Use_Only_Approved_Cipher_in_Counter_Mode
     replace_or_add 'Use Only Approved Cipher in Counter Mode' do
       path '/etc/ssh/sshd_config'
-      pattern "Ciphers.*"
-      line "Ciphers aes128-ctr,aes192-ctr,aes256-ctr"
+      pattern 'Ciphers.*'
+      line 'Ciphers aes128-ctr,aes192-ctr,aes256-ctr'
       notifies :create, 'file[sshd.changed]', :immediately
     end
     # End fix for xccdf_org.cisecurity.benchmarks_rule_6.2.11_Use_Only_Approved_Cipher_in_Counter_Mode

--- a/recipes/user-mgmt.rb
+++ b/recipes/user-mgmt.rb
@@ -7,7 +7,7 @@
 case node['platform_family']
 when 'rhel'
 
-# Begin xccdf_org.cisecurity.benchmarks_rule_7.5_Lock_Inactive_User_Accounts
+  # Begin xccdf_org.cisecurity.benchmarks_rule_7.5_Lock_Inactive_User_Accounts
   file '/etc/default/useradd' do
     mode '0644'
     owner 'root'
@@ -15,23 +15,23 @@ when 'rhel'
     action :create
   end
 
-  replace_or_add "User Inactive Enforcement" do
+  replace_or_add 'User Inactive Enforcement' do
     path '/etc/default/useradd'
-    pattern "INACTIVE"
-    line "INACTIVE=35"
+    pattern 'INACTIVE'
+    line 'INACTIVE=35'
   end
-# End xccdf_org.cisecurity.benchmarks_rule_7.5_Lock_Inactive_User_Accounts
+  # End xccdf_org.cisecurity.benchmarks_rule_7.5_Lock_Inactive_User_Accounts
 
-# Start fix for xccdf_org.cisecurity.benchmarks_rule_9.1.2_Verify_Permissions_on_etcpasswd
+  # Start fix for xccdf_org.cisecurity.benchmarks_rule_9.1.2_Verify_Permissions_on_etcpasswd
   file '/etc/passwd' do
     mode '0644'
     owner 'root'
     group 'root'
     action :create
   end
-# End fix for xccdf_org.cisecurity.benchmarks_rule_9.1.2_Verify_Permissions_on_etcpasswd
+  # End fix for xccdf_org.cisecurity.benchmarks_rule_9.1.2_Verify_Permissions_on_etcpasswd
 
-# Start fix for xccdf_org.cisecurity.benchmarks_rule_6.5_Restrict_Access_to_the_su_Command
+  # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.5_Restrict_Access_to_the_su_Command
   file '/etc/pam.d/su' do
     mode '0644'
     owner 'root'
@@ -39,14 +39,14 @@ when 'rhel'
     action :create
   end
 
-  replace_or_add "Restrict su Command" do
+  replace_or_add 'Restrict su Command' do
     path '/etc/pam.d/su'
-    pattern ".*pam_wheel.so use_uid"
-    line "auth            required        pam_wheel.so use_uid"
+    pattern '.*pam_wheel.so use_uid'
+    line 'auth            required        pam_wheel.so use_uid'
   end
-# End xccdf_org.cisecurity.benchmarks_rule_6.5_Restrict_Access_to_the_su_Command
+  # End xccdf_org.cisecurity.benchmarks_rule_6.5_Restrict_Access_to_the_su_Command
 
-# Start fix for xccdf_org.cisecurity.benchmarks_rule_7.4_Set_Default_umask_for_Users
+  # Start fix for xccdf_org.cisecurity.benchmarks_rule_7.4_Set_Default_umask_for_Users
   file '/etc/bashrc' do
     mode '0644'
     owner 'root'
@@ -54,14 +54,14 @@ when 'rhel'
     action :create
   end
 
-  replace_or_add "default umask for /etc/bashrc" do
+  replace_or_add 'default umask for /etc/bashrc' do
     path '/etc/bashrc'
-    pattern "^\s*umask\s"
-    line "    umask 077"
+    pattern '^\s*umask\s'
+    line '    umask 077'
   end
-# End fix for xccdf_org.cisecurity.benchmarks_rule_7.4_Set_Default_umask_for_Users
+  # End fix for xccdf_org.cisecurity.benchmarks_rule_7.4_Set_Default_umask_for_Users
 
-# Start fix for xccdf_org.cisecurity.benchmarks_rule_6.3.4_Limit_Password_Reuse
+  # Start fix for xccdf_org.cisecurity.benchmarks_rule_6.3.4_Limit_Password_Reuse
   file '/etc/pam.d/system-auth' do
     mode '0644'
     owner 'root'
@@ -69,11 +69,11 @@ when 'rhel'
     action :create
   end
 
-  replace_or_add "Limit Password Reusd" do
+  replace_or_add 'Limit Password Reusd' do
     path '/etc/pam.d/system-auth'
-    pattern "auth        sufficient    pam_unix.so remember=.*"
-    line "auth        sufficient    pam_unix.so remember=5"
+    pattern 'auth        sufficient    pam_unix.so remember=.*'
+    line 'auth        sufficient    pam_unix.so remember=5'
   end
-# End fix for xccdf_org.cisecurity.benchmarks_rule_6.3.4_Limit_Password_Reuse
+  # End fix for xccdf_org.cisecurity.benchmarks_rule_6.3.4_Limit_Password_Reuse
 
 end


### PR DESCRIPTION
Brings offenses down to 103. Passing Test Kitchen:

```
-----> Starting Kitchen (v1.7.3)
-----> Converging <default-rhel-7>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 4.3.2...
       Removing non-cookbook files before transfer
       Preparing solo.rb
-----> Chef Omnibus installation detected (install only if missing)
       Transferring files to <default-rhel-7>
       Starting Chef Client, version 12.9.38
       Installing Cookbook Gems:
       Compiling Cookbooks...
       [2016-05-04T11:34:57-04:00] WARN: Cloning resource attributes for yum_package[Install initscripts] from prior resource (CHEF-3694)
       [2016-05-04T11:34:57-04:00] WARN: Previous yum_package[Install initscripts]: /tmp/kitchen/cookbooks/cis-el7-l1-hardening/recipes/network-packet-remediation.rb:10:in `from_file'
       [2016-05-04T11:34:57-04:00] WARN: Current  yum_package[Install initscripts]: /tmp/kitchen/cookbooks/cis-el7-l1-hardening/recipes/default.rb:46:in `from_file'
       Converging 106 resources
       Recipe: cis-el7-l1-hardening::enable_sudo_no_tty
         * yum_package[Install sudo] action install (up to date)
         * file[/etc/sudoers] action create (up to date)
         * delete_lines[remove hash-comments from /some/file] action edit (up to date)
       Recipe: cis-el7-l1-hardening::ssh
         * yum_package[Install OpenSSH Server] action install (up to date)
         * service[sshd.service] action enable (up to date)
         * service[sshd.service] action start (up to date)
         * file[sshd.changed] action nothing (skipped due to action :nothing)
         * file[/etc/ssh/sshd_config] action create (up to date)
         * replace_or_add[SSH Protocol] action edit (up to date)
         * replace_or_add[SSH MaxAuthTries] action edit (up to date)
         * replace_or_add[Disable SSH X11 Forwarding] action edit (up to date)
         * replace_or_add[Set SSH IgnoreRhosts to Yes] action edit (up to date)
         * replace_or_add[Set SSH Banner] action edit (up to date)
         * delete_lines[Remove no default banner comment] action edit (up to date)
         * replace_or_add[Set SSH PermitEmptyPasswords to No] action edit (up to date)
         * replace_or_add[Disable SSH Root Login] action edit (up to date)
         * replace_or_add[Set SSH HostbasedAuthentication to No] action edit (up to date)
         * replace_or_add[Set LogLevel to INFO] action edit (up to date)
         * replace_or_add[Set Idle Timeout Interval for User Login - ClientAliveInterval] action edit (up to date)
         * replace_or_add[Set Idle Timeout Interval for User Login - ClientAliveCountMax] action edit (up to date)
         * replace_or_add[Do Not Allow Users to Set Environment Options] action edit (up to date)
         * replace_or_add[Set a DenyUsers config up] action edit (up to date)
         * replace_or_add[Set a DenyGroups config up] action edit (up to date)
         * replace_or_add[Use Only Approved Cipher in Counter Mode] action edit (up to date)
         * execute[Restart sshd only if config has changed] action run (skipped due to only_if)
       Recipe: cis-el7-l1-hardening::avahi
         * yum_package[Install Avahi Libs] action install (up to date)
         * yum_package[Install Avahi Autoipd] action install (up to date)
         * yum_package[Install Avahi] action install (up to date)
         * service[avahi-daemon.socket] action disable (up to date)
         * service[avahi-daemon.socket] action stop (up to date)
         * service[avahi-daemon.service] action disable (up to date)
         * service[avahi-daemon.service] action stop (up to date)
       Recipe: cis-el7-l1-hardening::cron
         * yum_package[Install cronie] action install (up to date)
         * service[crond] action enable (up to date)
         * service[crond] action start (up to date)
         * yum_package[Install cronie-anacron] action install (up to date)
         * yum_package[Install crontabs] action install (up to date)
         * directory[/etc/cron.d] action create (up to date)
         * directory[/etc/cron.monthly] action create (up to date)
         * directory[/etc/cron.weekly] action create (up to date)
         * directory[/etc/cron.daily] action create (up to date)
         * directory[/etc/cron.hourly] action create (up to date)
         * file[/etc/crontab] action create (up to date)
         * file[/etc/anacrontab] action create (up to date)
         * file[/etc/cron.deny] action delete (up to date)
         * file[/etc/cron.allow] action create (up to date)
       Recipe: cis-el7-l1-hardening::at_daemon
         * file[/etc/at.deny] action delete (up to date)
         * file[/etc/at.allow] action create (up to date)
       Recipe: cis-el7-l1-hardening::user-mgmt
         * file[/etc/default/useradd] action create (up to date)
         * replace_or_add[User Inactive Enforcement] action edit (up to date)
         * file[/etc/passwd] action create (up to date)
         * file[/etc/pam.d/su] action create (up to date)
         * replace_or_add[Restrict su Command] action edit (up to date)
         * file[/etc/bashrc] action create (up to date)
         * replace_or_add[default umask for /etc/bashrc] action edit (up to date)
         * file[/etc/pam.d/system-auth] action create[2016-05-04T11:34:58-04:00] WARN: File /etc/pam.d/system-auth managed by file[/etc/pam.d/system-auth] is really a symlink. Managing the source file instead.
       [2016-05-04T11:34:58-04:00] WARN: Disable this warning by setting `manage_symlink_source true` on the resource
       [2016-05-04T11:34:58-04:00] WARN: In a future Chef release, 'manage_symlink_source' will not be enabled by default
        (up to date)
         * replace_or_add[Limit Password Reusd] action edit (up to date)
       Recipe: cis-el7-l1-hardening::network-packet-remediation
         * yum_package[Install initscripts] action install (up to date)
         * yum_package[Install procps-ng] action install (up to date)
         * file[/etc/sysctl.conf] action create (up to date)
         * replace_or_add[enable_update_net.ipv4.conf.all.log_martians=1] action edit (up to date)
         * replace_or_add[enable_net.ipv4.conf.default.log_martians=1] action edit (up to date)
         * execute[update_net.ipv4.conf.all.log_martians=1] action run (skipped due to not_if)
         * execute[update_net.ipv4.conf.default.log_martians=1] action run (skipped due to not_if)
         * replace_or_add[enable_net.ipv4.conf.all.send_redirects=0] action edit (up to date)
         * replace_or_add[enable_net.ipv4.conf.default.send_redirects=0] action edit (up to date)
         * execute[update_net.ipv4.conf.all.send_redirects=0] action run (skipped due to not_if)
         * execute[update_net.ipv4.conf.default.send_redirects=0] action run (skipped due to not_if)
         * replace_or_add[enable_net.ipv4.conf.all.accept_redirects=0] action edit (up to date)
         * replace_or_add[enable_net.ipv4.conf.default.accept_redirects=0] action edit (up to date)
         * execute[update_net.ipv4.conf.all.accept_redirects=0] action run (skipped due to not_if)
         * execute[update_net.ipv4.conf.default.accept_redirects=0] action run (skipped due to not_if)
       Recipe: cis-el7-l1-hardening::login_banners
         * file[/etc/motd] action create (up to date)
         * execute[Delete OS Version from /etc/motd] action run (skipped due to only_if)
         * execute[Delete Kernel Version from /etc/motd] action run (skipped due to only_if)
         * execute[Delete Machine Architecture from /etc/motd] action run (skipped due to only_if)
         * execute[Delete OS used from /etc/motd] action run (skipped due to only_if)
         * file[/etc/issue] action create (up to date)
         * execute[Delete OS Version from /etc/issue] action run (skipped due to only_if)
         * execute[Delete Kernel Version from /etc/issue] action run (skipped due to only_if)
         * execute[Delete Machine Architecture from /etc/issue] action run (skipped due to only_if)
         * execute[Delete OS used from /etc/issue] action run (skipped due to only_if)
         * file[/etc/issue.net] action create (up to date)
         * execute[Delete OS Version from /etc/issue.net] action run (skipped due to only_if)
         * execute[Delete Kernel Version from /etc/issue.net] action run (skipped due to only_if)
         * execute[Delete Machine Architecture from /etc/issue.net] action run (skipped due to only_if)
         * execute[Delete OS used from /etc/issue.net] action run (skipped due to only_if)
       Recipe: cis-el7-l1-hardening::core_dumps
         * yum_package[Install pam] action install (up to date)
         * replace_or_add[Restrict Core Dumps] action edit (up to date)
       Recipe: cis-el7-l1-hardening::passwords
         * yum_package[Install libpwquality] action install (up to date)
         * file[/etc/security/pwquality.conf] action create (up to date)
         * replace_or_add[Set Password mimimum length] action edit (up to date)
         * replace_or_add[Set password dcredit] action edit (up to date)
         * replace_or_add[Set password ocredit] action edit (up to date)
         * replace_or_add[Set password lcredit] action edit (up to date)
         * replace_or_add[Set password ucredit] action edit (up to date)
         * execute[Set Password Expiring Warning Days in /etc/shadow] action run (skipped due to only_if)
         * replace_or_add[Set Password Expiration Days in login.defs] action edit (up to date)
         * execute[Set Password Expiration Days in /etc/shadow] action run (skipped due to only_if)
         * replace_or_add[Set Password Change Minimum Number of Days in login.defs] action edit (up to date)
         * execute[Set Password Change Minimum Number of Days in /etc/shadow] action run (skipped due to only_if)
       Recipe: cis-el7-l1-hardening::rsyslog
         * yum_package[Install rsyslog] action install (up to date)
         * service[rsyslog.service] action enable (up to date)
         * service[rsyslog.service] action start (up to date)
         * replace_or_add[Configure rsyslog to send logs to remote host] action edit (up to date)
       Recipe: cis-el7-l1-hardening::default
         * yum_package[firewalld] action install (up to date)
         * service[firewalld] action enable (up to date)
         * service[firewalld] action start (up to date)
         * yum_package[Install grub2] action install (up to date)
         * file[/boot/grub2/grub.cfg] action create (up to date)
         * yum_package[Install initscripts] action install (up to date)
         * replace_or_add[Set Daemon umask] action edit (up to date)

       Running handlers:
       Running handlers complete
       Chef Client finished, 0/112 resources updated in 03 seconds
       Finished converging <default-rhel-7> (0m10.47s).
-----> Kitchen is finished. (0m11.39s)
```
