### PR TITLE
Fix typo

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,6 @@ description 'Installs/Configures cis-el7-l1-hardening'
 long_description 'Installs/Configures cis-el7-l1-hardening'
 issues_url 'https://github.com/chef-customers/cis-el7-l1-hardening/issues'
 source_url 'https://github.com/chef-customers/cis-el7-l1-hardening'
-version '0.6.0'
+version '0.6.1'
 
 depends 'line', '~> 0.6.3'

--- a/recipes/ntp.rb
+++ b/recipes/ntp.rb
@@ -25,7 +25,7 @@ when 'rhel'
     # Correct ntp.conf config to conform to:
     # /^\s*restrict\s+default(?=[^#]*\s+kod)(?=[^#]*\s+nomodify)(?=[^#]*\s+notrap)(?=[^#]*\s+nopeer)(?=[^#]*\s+noquery)(\s+kod|\s+nomodify|\s+notrap|\s+nopeer|\s+noquery)*\s*(?:#.*)?$/
     replace_or_add 'Add kod to default restrict list in ntp.conf for IP V4' do
-      path '/etc/ntp.conf v4'
+      path '/etc/ntp.conf'
       pattern "^restrict\sdefault"
       line 'restrict default kod nomodify notrap nopeer noquery'
     end


### PR DESCRIPTION
The ntp recipe has the wrong path for one of the resources `/etc/ntp.conf v4` instead of `/etc/ntp.conf`. This fixes that. 
