### PR TITLE
Clean Up default.rb and bring some sanity -- version 0.7.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,6 @@ description 'Installs/Configures cis-el7-l1-hardening'
 long_description 'Installs/Configures cis-el7-l1-hardening'
 issues_url 'https://github.com/chef-cookbooks/cis-el7-l1-hardening/issues'
 source_url 'https://github.com/chef-cookbooks/cis-el7-l1-hardening'
-version '0.6.2'
+version '0.7.0'
 
 depends 'line', '~> 0.6.3'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,57 +7,25 @@ case node['platform_family']
 when 'rhel'
   if node['platform_version'].to_f >= 7.0
 
-    # Fix for "xccdf_org.cisecurity.benchmarks_rule_4.7_Enable_firewalld"
-    package 'firewalld'
-
-    service 'firewalld' do
-      supports :status => true
-      action [:enable, :start]
-    end
-    # End fix for "xccdf_org.cisecurity.benchmarks_rule_4.7_Enable_firewalld"
-
-    # Start fix for xccdf_org.cisecurity.benchmarks_rule_1.5.2_Set_Permissions_on_bootgrub2grub.cfg
-    package 'Install grub2' do
-      package_name 'grub2'
-      action :install
-    end
-
-    file '/boot/grub2/grub.cfg' do
-      mode '0600'
-      owner 'root'
-      group 'root'
-      action :create
-    end
-    # End fix for xccdf_org.cisecurity.benchmarks_rule_1.5.2_Set_Permissions_on_bootgrub2grub.cfg
-
-    # Start fix for xccdf_org.cisecurity.benchmarks_rule_3.1_Set_Daemon_umask
-    package 'Install initscripts' do
-      package_name 'initscripts'
-      action :install
-    end
-
-    replace_or_add 'Set Daemon umask' do
-      path '/etc/sysconfig/init'
-      pattern 'umask 027'
-      line 'umask 027'
-    end
-    # End fix for xccdf_org.cisecurity.benchmarks_rule_3.1_Set_Daemon_umask
-
-    # Recipe includes
-    include_recipe 'cis-el7-l1-hardening::ssh'
-    include_recipe 'cis-el7-l1-hardening::avahi'
-    include_recipe 'cis-el7-l1-hardening::cron'
+    # Remiation recipes includes (alphabetical)
     include_recipe 'cis-el7-l1-hardening::at_daemon'
-    include_recipe 'cis-el7-l1-hardening::network-packet-remediation'
-    include_recipe 'cis-el7-l1-hardening::login_banners'
+    include_recipe 'cis-el7-l1-hardening::avahi'
     include_recipe 'cis-el7-l1-hardening::core_dumps'
-    include_recipe 'cis-el7-l1-hardening::rsyslog'
+    include_recipe 'cis-el7-l1-hardening::cron'
+    include_recipe 'cis-el7-l1-hardening::firewalld'
+    include_recipe 'cis-el7-l1-hardening::grub'
+    include_recipe 'cis-el7-l1-hardening::init'
+    include_recipe 'cis-el7-l1-hardening::login_banners'
+    include_recipe 'cis-el7-l1-hardening::network-packet-remediation'
     include_recipe 'cis-el7-l1-hardening::ntp'
+    include_recipe 'cis-el7-l1-hardening::rsyslog'
+    include_recipe 'cis-el7-l1-hardening::ssh'
     include_recipe 'cis-el7-l1-hardening::user-mgmt'
 
     # This should be the last recipe thats run as it remediates
-    # the shadow file to a CIS compliant standard.
-
+    # the shadow file to a CIS compliant standard and prior recipes may have
+    # influence additions / removals to the shadow file.
+    #
     include_recipe 'cis-el7-l1-hardening::passwords'
 
   end

--- a/recipes/firewalld.rb
+++ b/recipes/firewalld.rb
@@ -1,0 +1,13 @@
+# Cookbook Name:: cis-el7-l1-hardening
+# Recipe:: firewalld
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+# Fix for "xccdf_org.cisecurity.benchmarks_rule_4.7_Enable_firewalld"
+package 'firewalld'
+
+service 'firewalld' do
+  supports :status => true
+  action [:enable, :start]
+end
+# End fix for "xccdf_org.cisecurity.benchmarks_rule_4.7_Enable_firewalld"

--- a/recipes/grub.rb
+++ b/recipes/grub.rb
@@ -1,0 +1,19 @@
+# Cookbook Name:: cis-el7-l1-hardening
+# Recipe:: grub
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+
+# Start fix for xccdf_org.cisecurity.benchmarks_rule_1.5.2_Set_Permissions_on_bootgrub2grub.cfg
+package 'Install grub2' do
+  package_name 'grub2'
+  action :install
+end
+
+file '/boot/grub2/grub.cfg' do
+  mode '0600'
+  owner 'root'
+  group 'root'
+  action :create
+end
+# End fix for xccdf_org.cisecurity.benchmarks_rule_1.5.2_Set_Permissions_on_bootgrub2grub.cfg

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -1,0 +1,17 @@
+# Cookbook Name:: cis-el7-l1-hardening
+# Recipe:: init
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+# Start fix for xccdf_org.cisecurity.benchmarks_rule_3.1_Set_Daemon_umask
+package 'Install initscripts' do
+  package_name 'initscripts'
+  action :install
+end
+
+replace_or_add 'Set Daemon umask' do
+  path '/etc/sysconfig/init'
+  pattern 'umask 027'
+  line 'umask 027'
+end
+# End fix for xccdf_org.cisecurity.benchmarks_rule_3.1_Set_Daemon_umask


### PR DESCRIPTION
- Remove firewalld from default; create firewalld.rb  
- Remove init remediation from default; create init.rb
- Remove grub remediation from default; create grub.rb
- Remove firewalld, grub and init remediation from default. Alphabetize remediation recipes except for passwords due to shadow file
- Bump version to 0.7.0
